### PR TITLE
Use CIGAR strings to determine sequence cut position

### DIFF
--- a/AmpliGone/AmpliGone.py
+++ b/AmpliGone/AmpliGone.py
@@ -17,7 +17,7 @@ import pandas as pd
 import parmap
 
 from .CoordinateSearch import MakeCoordinateLists, WritePrimerExports
-from .cut_reads import End_to_End, End_to_Mid
+from .cut_reads import CutReads
 from .func import MyHelpFormatter, color
 from .io_ops import IndexReads, WriteOutput
 from .mappreset import FindPreset
@@ -158,7 +158,7 @@ def get_args(givenargs):
     return flags
 
 
-def parallel(frame, function, workers, LeftPrimers, RightPrimers, reference, preset):
+def parallel(frame, function, workers, LeftPrimers, RightPrimers, reference, preset, amplicon_type):
     frame_split = np.array_split(frame, workers)
     tr = [*range(workers)]
     readframe = pd.concat(
@@ -170,6 +170,7 @@ def parallel(frame, function, workers, LeftPrimers, RightPrimers, reference, pre
             reference,
             preset,
             workers,
+            amplicon_type,
             pm_processes=workers,
         )
     )
@@ -210,7 +211,7 @@ def main():
             f"""
     {color.RED}AmpliGone was given an empty input file. Exiting...
     Please check the input file to make sure this is correct{color.END}
-    
+
     {color.YELLOW}Use the -to flag to force AmpliGone to create an output file even if there is nothing to output.{color.END}
     """
         )
@@ -242,24 +243,26 @@ def main():
 
         ProcessedReads = parallel(
             IndexedReads,
-            End_to_End,
+            CutReads,
             args.threads,
             LeftPrimers,
             RightPrimers,
             args.reference,
             preset,
+            amplicon_type=args.amplicon_type,
         )
         ProcessedReads.reset_index(drop=True)
 
     if args.amplicon_type == "end-to-mid":
         ProcessedReads = parallel(
             IndexedReads,
-            End_to_Mid,
+            CutReads,
             args.threads,
             LeftPrimers,
             RightPrimers,
             args.reference,
             preset,
+            amplicon_type=args.amplicon_type,
         )
         ProcessedReads.reset_index(drop=True)
 

--- a/AmpliGone/cut_reads.py
+++ b/AmpliGone/cut_reads.py
@@ -64,7 +64,7 @@ def CutReads(data, FWList, RVList, reference, preset, workers, amplicon_type):
 
             removed_coords_fw = removed_coords_rv = []
 
-            if amplicon_type == 'end-to-end' or (amplicon_type == 'end_to_mid' and hit.strand == 1):
+            if amplicon_type == 'end-to-end' or (amplicon_type == 'end-to-mid' and hit.strand == 1):
                 seq, qual, removed_coords_fw = cut_read(
                     seq, qual,
                     PositionNeedsCutting=PositionInOrBeforePrimer,
@@ -75,7 +75,7 @@ def CutReads(data, FWList, RVList, reference, preset, workers, amplicon_type):
                     cigar=hit.cigar,
                     )
 
-            if amplicon_type == 'end-to-end' or (amplicon_type == 'end_to_mid' and hit.strand == -1):
+            if amplicon_type == 'end-to-end' or (amplicon_type == 'end-to-mid' and hit.strand == -1):
                 seq, qual, removed_coords_rv = cut_read(
                     seq, qual,
                     PositionNeedsCutting=PositionInOrAfterPrimer,

--- a/AmpliGone/cut_reads.py
+++ b/AmpliGone/cut_reads.py
@@ -28,11 +28,11 @@ def cut_read(seq, qual, PositionNeedsCutting, primer_list, position_on_reference
             cigar_len -= 1
             removed_coords.append(position_on_reference)
 
-            # Increment position on sequence if match/insert(in seq)/mismatch
+            # Increment position on sequence if match/insert (in seq)/mismatch
             if cigar_type in (0,1,4):
                 position_on_sequence += read_direction*cut_direction
 
-            # Increment position on reference if match/insert(in seq)/mismatch
+            # Increment position on reference if match/deletion (in seq)/mismatch
             if cigar_type in (0,2,3):
                 position_on_reference += cut_direction
 

--- a/AmpliGone/cut_reads.py
+++ b/AmpliGone/cut_reads.py
@@ -1,10 +1,13 @@
 import mappy as mp
 import numpy as np
 import pandas as pd
+import itertools
 
 from .cutlery import (
     ReadAfterPrimer,
     ReadBeforePrimer,
+    ReadInOrBeforePrimer,
+    ReadInOrAfterPrimer,
     slice_fw_left,
     slice_fw_right,
     slice_rv_left,
@@ -14,6 +17,7 @@ from .cutlery import (
 
 def End_to_End(data, FWList, RVList, reference, preset, workers):
     Frame, threadnumber = data
+    FWSet, RVSet = set(FWList), set(RVList)
 
     readnames = Frame["Readname"].tolist()
     sequences = Frame["Sequence"].tolist()
@@ -25,6 +29,8 @@ def End_to_End(data, FWList, RVList, reference, preset, workers):
     processed_sequences = []
     processed_qualities = []
     removed_coords = []
+
+    new_method = 0
 
     for i in range(len(readnames)):
         name = readnames[i]
@@ -48,86 +54,113 @@ def End_to_End(data, FWList, RVList, reference, preset, workers):
             end = hit.r_en
 
             if reverse is False:
-
-                while ReadBeforePrimer(start, FWList) is True:
-                    seq, qual, start = slice_fw_left(start, seq, qual)
-
-                    hitlimit = 0
+                if ReadInOrAfterPrimer(end, RVList):
+                    seq_pos_to_cut = len(seq)
+                    ref_pos_to_cut = end
                     for hit2 in Aln.map(seq):
-                        if hitlimit != 0:
-                            continue
-                        hitlimit += 1
-                        start = hit2.r_st
+                        for cigar_len, cigar_type in reversed(hit2.cigar):
+                            if not ReadInOrAfterPrimer(ref_pos_to_cut, RVList):
+                                break
+                            while cigar_len > 0 and ReadInOrAfterPrimer(ref_pos_to_cut, RVList):
+                                cigar_len -= 1
+                                if cigar_type == 0 or cigar_type == 3: # MATCH or MISMATCH
+                                    seq_pos_to_cut -= 1
+                                    ref_pos_to_cut -= 1
+                                elif cigar_type == 1: # Insertion in seq
+                                    seq_pos_to_cut -= 1
+                                elif cigar_type == 2: # Deletion in seq
+                                    ref_pos_to_cut -= 1
+                                else:
+                                    raise ValueError(f'Error in finding position to cut read:\nCigar type {cigar_type} does not exist')
+                        seq = seq[:seq_pos_to_cut]
+                        qual = qual[:seq_pos_to_cut]
+                        new_method += 1
 
-                while ReadAfterPrimer(end, RVList) is True:
-                    seq, qual, end = slice_fw_right(end, seq, qual)
-
-                    hitlimit = 0
-                    for hit2 in Aln.map(seq):
-                        if hitlimit != 0:
-                            continue
-                        hitlimit += 1
-                        end = hit2.r_en
-
-                while (end in RVList) is True:
-                    rmc.append(end)
-                    seq, qual, end = slice_fw_right(end, seq, qual)
-                    hitlimit = 0
-                    for hit2 in Aln.map(seq):
-                        if hitlimit != 0:
-                            continue
-                        hitlimit += 1
-                        end = hit2.r_en
-
-                while (start in FWList) is True:
-                    rmc.append(start)
-                    seq, qual, start = slice_fw_left(start, seq, qual)
-                    hitlimit = 0
-                    for hit2 in Aln.map(seq):
-                        if hitlimit != 0:
-                            continue
-                        hitlimit += 1
-                        start = hit2.r_st
+                if ReadInOrBeforePrimer(start, FWList):
+                    seq_pos_to_cut = 0
+                    ref_pos_to_cut = start
+                    for cigar_len, cigar_type in hit.cigar:
+                        if not ReadInOrBeforePrimer(ref_pos_to_cut, FWList):
+                            break
+                        while cigar_len > 0 and ReadInOrBeforePrimer(ref_pos_to_cut, FWList):
+                            cigar_len -= 1
+                            if cigar_type == 0 or cigar_type == 3: # MATCH or MISMATCH
+                                seq_pos_to_cut += 1
+                                ref_pos_to_cut += 1
+                            elif cigar_type == 1: # Insertion in seq
+                                seq_pos_to_cut += 1
+                            elif cigar_type == 2: # Deletion in seq
+                                ref_pos_to_cut += 1
+                            else:
+                                raise ValueError(f'Error in finding position to cut read:\nCigar type {cigar_type} does not exist')
+                    seq = seq[seq_pos_to_cut:]
+                    qual = qual[seq_pos_to_cut:]
+                    new_method += 1
 
             if reverse is True:
 
-                while ReadBeforePrimer(start, FWList) is True:
-                    seq, qual, start = slice_rv_left(start, seq, qual)
-                    hitlimit = 0
+                if ReadInOrBeforePrimer(start, FWList):
+                    seq_pos_to_cut = len(seq)
+                    ref_pos_to_cut = start
                     for hit2 in Aln.map(seq):
-                        if hitlimit != 0:
-                            continue
-                        hitlimit += 1
-                        start = hit2.r_st
+                        for cigar_len, cigar_type in hit2.cigar:
+                            if not ReadInOrBeforePrimer(ref_pos_to_cut, FWList):
+                                break
+                            while cigar_len > 0 and ReadInOrBeforePrimer(ref_pos_to_cut, FWList):
+                                cigar_len -= 1
+                                if cigar_type == 0 or cigar_type == 3: # MATCH or MISMATCH
+                                    seq_pos_to_cut -= 1
+                                    ref_pos_to_cut += 1
+                                elif cigar_type == 1: # Insertion in seq
+                                    seq_pos_to_cut -= 1
+                                elif cigar_type == 2: # Deletion in seq
+                                    ref_pos_to_cut += 1
+                                else:
+                                    raise ValueError(f'Error in finding position to cut read:\nCigar type {cigar_type} does not exist')
+                        seq = seq[:seq_pos_to_cut]
+                        qual = qual[:seq_pos_to_cut]
+                        new_method += 1
 
-                while ReadAfterPrimer(end, RVList) is True:
-                    seq, qual, end = slice_rv_right(end, seq, qual)
-                    hitlimit = 0
+                if ReadInOrAfterPrimer(end, RVList):
+                    seq_pos_to_cut = 0
+                    ref_pos_to_cut = end
                     for hit2 in Aln.map(seq):
-                        if hitlimit != 0:
-                            continue
-                        hitlimit += 1
-                        end = hit2.r_en
+                        for cigar_len, cigar_type in hit2.cigar:
+                            if not ReadInOrAfterPrimer(ref_pos_to_cut, RVList):
+                                break
+                            while cigar_len > 0 and ReadInOrAfterPrimer(ref_pos_to_cut, RVList):
+                                cigar_len -= 1
+                                if cigar_type == 0 or cigar_type == 3: # MATCH or MISMATCH
+                                    seq_pos_to_cut += 1
+                                    ref_pos_to_cut -= 1
+                                elif cigar_type == 1: # Insertion in seq
+                                    seq_pos_to_cut += 1
+                                elif cigar_type == 2: # Deletion in seq
+                                    ref_pos_to_cut -= 1
+                                else:
+                                    raise ValueError(f'Error in finding position to cut read:\nCigar type {cigar_type} does not exist')
+                        seq = seq[seq_pos_to_cut:]
+                        qual = qual[seq_pos_to_cut:]
+                        new_method += 1
 
-                while (start in FWList) is True:
-                    rmc.append(start)
-                    seq, qual, start = slice_rv_left(start, seq, qual)
-                    hitlimit = 0
-                    for hit2 in Aln.map(seq):
-                        if hitlimit != 0:
-                            continue
-                        hitlimit += 1
-                        start = hit2.r_st
+                # while ReadAfterPrimer(end, RVList) is True:
+                #     seq, qual, end = slice_rv_right(end, seq, qual)
+                #     hitlimit = 0
+                #     for hit2 in Aln.map(seq):
+                #         if hitlimit != 0:
+                #             continue
+                #         hitlimit += 1
+                #         end = hit2.r_en
 
-                while (end in RVList) is True:
-                    rmc.append(end)
-                    seq, qual, end = slice_rv_right(end, seq, qual)
-                    hitlimit = 0
-                    for hit2 in Aln.map(seq):
-                        if hitlimit != 0:
-                            continue
-                        hitlimit += 1
-                        end = hit2.r_en
+                # while (end in RVSet) is True:
+                #     rmc.append(end)
+                #     seq, qual, end = slice_rv_right(end, seq, qual)
+                #     hitlimit = 0
+                #     for hit2 in Aln.map(seq):
+                #         if hitlimit != 0:
+                #             continue
+                #         hitlimit += 1
+                #         end = hit2.r_en
 
         if len(seq) < 5:
             seq = np.nan
@@ -139,6 +172,7 @@ def End_to_End(data, FWList, RVList, reference, preset, workers):
         processed_qualities.append(qual)
         removed_coords.append(rmc)
 
+    print(f"Removed with new_method: {new_method}")
     ProcessedReads = pd.DataFrame(
         {
             "Readname": processed_readnames,

--- a/AmpliGone/cutlery.py
+++ b/AmpliGone/cutlery.py
@@ -1,5 +1,22 @@
 from functools import lru_cache
 
+@lru_cache(maxsize=2000000)
+def ReadInOrBeforePrimer(pos, clist):
+    d = lambda x: abs(x - pos)
+    near = min(clist, key=d)
+    if pos <= near:
+        return True
+    else:
+        return False
+
+@lru_cache(maxsize=2000000)
+def ReadInOrAfterPrimer(pos, clist):
+    d = lambda x: abs(x - pos)
+    near = min(clist, key=d)
+    if pos >= near:
+        return True
+    else:
+        return False
 
 @lru_cache(maxsize=2000000)
 def ReadBeforePrimer(pos, clist):

--- a/AmpliGone/cutlery.py
+++ b/AmpliGone/cutlery.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 
 @lru_cache(maxsize=2000000)
-def ReadInOrBeforePrimer(pos, clist):
+def PositionInOrBeforePrimer(pos, clist):
     d = lambda x: abs(x - pos)
     near = min(clist, key=d)
     if pos <= near:
@@ -10,7 +10,7 @@ def ReadInOrBeforePrimer(pos, clist):
         return False
 
 @lru_cache(maxsize=2000000)
-def ReadInOrAfterPrimer(pos, clist):
+def PositionInOrAfterPrimer(pos, clist):
     d = lambda x: abs(x - pos)
     near = min(clist, key=d)
     if pos >= near:

--- a/AmpliGone/cutlery.py
+++ b/AmpliGone/cutlery.py
@@ -4,19 +4,13 @@ from functools import lru_cache
 def PositionInOrBeforePrimer(pos, clist):
     d = lambda x: abs(x - pos)
     near = min(clist, key=d)
-    if pos <= near:
-        return True
-    else:
-        return False
+    return pos <= near
 
 @lru_cache(maxsize=2000000)
 def PositionInOrAfterPrimer(pos, clist):
     d = lambda x: abs(x - pos)
     near = min(clist, key=d)
-    if pos >= near:
-        return True
-    else:
-        return False
+    return pos >= near
 
 @lru_cache(maxsize=2000000)
 def ReadBeforePrimer(pos, clist):


### PR DESCRIPTION
This commit uses CIGAR strings to find the position on the sequence from which to cut. An added benifit is that the overall runtime is about 3.5x shorter.