### PR TITLE
Add optional arguments to manually set alignment preset and alignment scoring-matrix

### DIFF
--- a/AmpliGone/AmpliGone.py
+++ b/AmpliGone/AmpliGone.py
@@ -25,7 +25,7 @@ from .cut_reads import CutReads
 from .fasta2bed import CoordinateListsToBed, MakeCoordinateLists
 from .func import FlexibleArgFormatter, RichParser, log
 from .io_ops import IndexReads, WriteOutput, read_bed
-from .mappreset import FindPreset
+from .mappreset import FindPreset, parse_scoring_matrix
 from .version import __version__
 
 
@@ -195,6 +195,28 @@ def get_args(givenargs: List[str]) -> argparse.Namespace:
     )
 
     optional_args.add_argument(
+        "--alignment-preset",
+        "-ap",
+        type=str,
+        default=None,
+        choices=("sr", "map-ont", "map-pb", "splice"),
+        help="The preset to use for alignment of reads against the reference. This can be either 'sr', 'map-ont', 'map-pb', or 'splice'. The alignment-preset can be combined with a custom alignment-scoring matrix. See the docs for more info :book:",
+        required=False,
+        metavar="'sr'/'map-ont'/'map-pb'/'splice'",
+    )
+
+    optional_args.add_argument(
+        "--alignment-scoring",
+        "-as",
+        type=str,
+        default=None,
+        metavar="KEY=VALUE",
+        nargs="+",
+        help="The scoring matrix to use for alignment of reads. This should be list of key-value pairs, where the key is the scoring-parameter and the value is a positive integer indicating the scoring-value for that parameter. Possible parameters are \n * match\n * mismatch\n * gap_o1\n * gap_e1\n * gap_o2 (optional)\n * gap_e2 (optional)\n * mma (optional)\nFor example:\n --alignment-scoring match=4 mismatch=3 gap_o1=2 gap_o2=1 gap_e1=1 gap_e2=1 mma=2\nSee the docs for more info :book:",
+        required=False,
+    )
+
+    optional_args.add_argument(
         "--version",
         "-v",
         action="version",
@@ -331,15 +353,24 @@ def main():
         )
         args.threads = len(IndexedReads.index)
 
-    log.info("Finding optimal alignment parameters for the given reads")
-    # Todo: split this over two threads if possible
-    if len(IndexedReads.index) > 20000:
-        preset, scoring = FindPreset(
-            args.threads, IndexedReads.sample(frac=0.3)
-        )  # Todo: Make this more efficient
-    else:
-        preset, scoring = FindPreset(args.threads, IndexedReads)
+    preset: str = args.alignment_preset
+    if preset is None:
+        log.info("Finding optimal alignment-preset for the given reads")
+        # Todo: split this over two threads if possible
+        if len(IndexedReads.index) > 20000:
+            preset = FindPreset(
+                args.threads, IndexedReads.sample(frac=0.3)
+            )  # Todo: Make this more efficient
+        else:
+            preset = FindPreset(args.threads, IndexedReads)
 
+    if args.alignment_scoring is not None:
+        log.info("Alignment scoring values given, parsing to scoring-matrix")
+        scoring = parse_scoring_matrix(args.alignment_scoring)
+    else:
+        scoring = []
+
+    print(preset, scoring)
     ## correct the lookaround size if the amplicon type is not fragmented
     if args.amplicon_type != "fragmented":
         args.fragment_lookaround_size = 10000

--- a/AmpliGone/AmpliGone.py
+++ b/AmpliGone/AmpliGone.py
@@ -212,7 +212,7 @@ def get_args(givenargs: List[str]) -> argparse.Namespace:
         default=None,
         metavar="KEY=VALUE",
         nargs="+",
-        help="The scoring matrix to use for alignment of reads. This should be list of key-value pairs, where the key is the scoring-parameter and the value is a positive integer indicating the scoring-value for that parameter. Possible parameters are \n * match\n * mismatch\n * gap_o1\n * gap_e1\n * gap_o2 (optional)\n * gap_e2 (optional)\n * mma (optional)\nFor example:\n --alignment-scoring match=4 mismatch=3 gap_o1=2 gap_e1=1\nSee the docs for more info :book:",
+        help="The scoring matrix to use for alignment of reads. This should be list of key-value pairs, where the key is the scoring-parameter and the value is a positive integer indicating the scoring-value for that parameter. Possible parameters are \n * (1) match\n * (2) mismatch\n * (3) gap_o1\n * (4) gap_e1\n * (5) gap_o2 (Optional: requires 1,2,3,4)\n * (6) gap_e2 (Optional, requires 1,2,3,4,5)\n * (7) mma (Optional, requires 1,2,3,4,5,6)\nFor example:\n --alignment-scoring match=4 mismatch=3 gap_o1=2 gap_e1=1\nSee the docs for more info :book:",
         required=False,
     )
 
@@ -366,7 +366,7 @@ def main():
 
     if args.alignment_scoring is not None:
         log.info("Alignment scoring values given, parsing to scoring-matrix")
-        scoring = parse_scoring_matrix(args.alignment_scoring)
+        scoring = parse_scoring_matrix(sorted(args.alignment_scoring))
     else:
         scoring = []
 

--- a/AmpliGone/AmpliGone.py
+++ b/AmpliGone/AmpliGone.py
@@ -212,7 +212,7 @@ def get_args(givenargs: List[str]) -> argparse.Namespace:
         default=None,
         metavar="KEY=VALUE",
         nargs="+",
-        help="The scoring matrix to use for alignment of reads. This should be list of key-value pairs, where the key is the scoring-parameter and the value is a positive integer indicating the scoring-value for that parameter. Possible parameters are \n * match\n * mismatch\n * gap_o1\n * gap_e1\n * gap_o2 (optional)\n * gap_e2 (optional)\n * mma (optional)\nFor example:\n --alignment-scoring match=4 mismatch=3 gap_o1=2 gap_o2=1 gap_e1=1 gap_e2=1 mma=2\nSee the docs for more info :book:",
+        help="The scoring matrix to use for alignment of reads. This should be list of key-value pairs, where the key is the scoring-parameter and the value is a positive integer indicating the scoring-value for that parameter. Possible parameters are \n * match\n * mismatch\n * gap_o1\n * gap_e1\n * gap_o2 (optional)\n * gap_e2 (optional)\n * mma (optional)\nFor example:\n --alignment-scoring match=4 mismatch=3 gap_o1=2 gap_e1=1\nSee the docs for more info :book:",
         required=False,
     )
 

--- a/AmpliGone/mappreset.py
+++ b/AmpliGone/mappreset.py
@@ -309,7 +309,7 @@ def scoring_has_negative_values(input_list: List[int]) -> bool:
 
 def parse_scoring_matrix(input_matrix: List[str]) -> List[int]:
     """
-    Parse the scoring matrix from a list of strings to a list of integers.
+    Parse the scoring matrix from a list of 'key=value' strings to a list of integers matching the required scoring matrix order.
 
     Parameters
     ----------
@@ -319,7 +319,7 @@ def parse_scoring_matrix(input_matrix: List[str]) -> List[int]:
     Returns
     -------
     list of int
-        The scoring matrix as a list of integers, ordered according to the keys in the input.
+        The scoring matrix as a list of integers, ordered to fit the mappy input.
 
     Raises
     ------
@@ -327,15 +327,17 @@ def parse_scoring_matrix(input_matrix: List[str]) -> List[int]:
         If the input matrix is invalid (e.g., wrong length, contains negative values, invalid keys).
 
     """
-    required_4 = ["match", "mismatch", "gap_o1", "gap_e1"]
-    required_6 = required_4 + ["gap_o2", "gap_e2"]
-    required_7 = required_6 + ["mma"]
+    required_4 = sorted(["match", "mismatch", "gap_o1", "gap_e1"])
+    required_6 = sorted(required_4 + ["gap_o2", "gap_e2"])
+    required_7 = sorted(required_6 + ["mma"])
 
-    matrix_dict = {item.split("=")[0]: int(item.split("=")[1]) for item in input_matrix}
+    matrix_dict = {
+        item.split("=")[0]: int(item.split("=")[1]) for item in sorted(input_matrix)
+    }
 
     if valid_scoring_list_length(list(matrix_dict.keys())) is False:
         log.error(
-            f"Invalid scoring matrix length. The scoring-matrix must have a length of 4, 6 or 7. \nThe following input was given: '[red]{' '.join(input_matrix)}[/red]'. \nPlease note that adding the same key multiple times will result in the last value being used."
+            f"Invalid scoring matrix length. The scoring-matrix must have a length of 4, 6 or 7 parameters. \nThe following input parameters were given: '[red]{' '.join(input_matrix)}[/red]'. \nAfter parsing, these inputs result in the following: [red]{matrix_dict}[/red]. \nPlease note that adding the same key multiple times will result in the last value being used."
         )
         sys.exit(1)
 
@@ -348,31 +350,26 @@ def parse_scoring_matrix(input_matrix: List[str]) -> List[int]:
 
     # this section is quite redundant and the same thing is being done multiple times, will see to optimize it later but this is reasonably valid for now.
     ordered_vals: List[int] = []
-    if len(matrix_dict.keys()) == 4:
-        if not set(matrix_dict.keys()).issubset(required_4):
+    matrix_keys = list(matrix_dict.keys())
+    if len(matrix_keys) == 4:
+        if not set(matrix_keys).issubset(required_4):
             log.error(
-                f"Invalid combination of scoring matrix keys. A total of 4 valid scoring-matrix keys were given. \nThe following keys are supported for 4 scoring-matrix keys: '[green]{' | '.join(required_4)}[/green]'. \nThe following keys were given: '[red]{' | '.join(matrix_dict.keys())}[/red]'."
+                f"Invalid combination of scoring matrix keys. A total of 4 valid scoring-matrix keys were given. \nThe following keys are supported for 4 scoring-matrix keys: '[green]{' | '.join(required_4)}[/green]'. \nThe following keys were given: '[red]{' | '.join(matrix_keys)}[/red]'."
             )
             sys.exit(1)
-        ordered_vals: List[int] = [
-            matrix_dict[key] for key in required_4 if key in matrix_dict
-        ]
-    elif len(matrix_dict.keys()) == 6:
-        if set(required_6) != set(matrix_dict.keys()):
+        ordered_vals = [matrix_dict[key] for key in required_4]
+    elif len(matrix_keys) == 6:
+        if not set(matrix_keys).issubset(required_6):
             log.error(
-                f"Invalid combination of scoring matrix keys. A total of 6 valid scoring-matrix keys were given. \nThe following keys are supported for 6 scoring-matrix keys: '[green]{' | '.join(required_6)}[/green]'. \nThe following keys were given: '[red]{' | '.join(matrix_dict.keys())}[/red]'."
+                f"Invalid combination of scoring matrix keys. A total of 6 valid scoring-matrix keys were given. \nThe following keys are supported for 6 scoring-matrix keys: '[green]{' | '.join(required_6)}[/green]'. \nThe following keys were given: '[red]{' | '.join(matrix_keys)}[/red]'."
             )
             sys.exit(1)
-        ordered_vals: List[int] = [
-            matrix_dict[key] for key in required_6 if key in matrix_dict
-        ]
-    elif len(matrix_dict.keys()) == 7:
-        if set(required_7) != set(matrix_dict.keys()):
+        ordered_vals = [matrix_dict[key] for key in required_6]
+    elif len(matrix_keys) == 7:
+        if not set(matrix_keys).issubset(required_7):
             log.error(
-                f"Invalid combination of scoring matrix keys. A total of 7 valid scoring-matrix keys were given. \nThe following keys are supported for 7 scoring-matrix keys: '[green]{' | '.join(required_7)}[/green]'. \nThe following keys were given: '[red]{' | '.join(matrix_dict.keys())}[/red]'."
+                f"Invalid combination of scoring matrix keys. A total of 7 valid scoring-matrix keys were given. \nThe following keys are supported for 7 scoring-matrix keys: '[green]{' | '.join(required_7)}[/green]'. \nThe following keys were given: '[red]{' | '.join(matrix_keys)}[/red]'."
             )
             sys.exit(1)
-        ordered_vals: List[int] = [
-            matrix_dict[key] for key in required_7 if key in matrix_dict
-        ]
+        ordered_vals = [matrix_dict[key] for key in required_7]
     return ordered_vals

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -82,6 +82,68 @@ Therefore, AmpliGone scales (almost) linearly when given more threads. A compute
 AmpliGone defaults to the amount of threads which are available in your system. (if the CPU of your computer has 24 threads, AmpliGone will use all 24 threads by default)
 You can use the `--threads` or `-t` flag to set a different number of threads to use.
 
+## Adjusting alignment-preset and scoring matrix
+
+AmpliGone relies on minimap2 for read-mapping under the hood. Therefore, the read-mapping settings usually don't need to be adjusted for your data as the existing presets are already fine-tuned for most situations. AmpliGone has a system in place that can assign the best fitting alignment-preset based on your data.
+
+However, in certain edge-cases it may be beneficial or necessary to change the preset manually or even make adjustments to the underlying alignment scoring-matrix.
+These settings can be changed with the `--alignment-preset` and `--alignment-scoring` flags respectively.
+
+**Alignment preset**
+
+The following 4 read-alignment presets are supported:
+
+| Preset keyword | Intended use |
+| ---            | ---          |
+| sr             | Short reads with high accuracy |
+| map-ont   	 | Long reads with lesser accuracy, specifically from the Nanopore platform |
+| map-pb         | PacBio continuous long reads (CLR) |
+| splice         | Long reads with splicing mode enabled |
+
+When no alignment-preset is given manually, AmpliGone will choose between either the `sr` or the `map-ont` preset depending on your input data.
+
+The alignment-preset can be set manually by using the `--alignment-preset` / `-ap` flag with any of the presets listed above.  
+Example: `--alignment-preset sr`
+
+**Alignment scoring-matrix**
+
+When no scoring-matrix is given then the default scoring matrix values will be used that fit the alignment-preset. These default scoring values are most likely fine for the majority of use cases.  
+However, it may be beneficial to fine tune the scoring matrix to your liking if this is better for your specific analysis.
+
+This can be done by using the `--alignment-scoring`/`-as` flag and providing a set of key=value pairs.
+
+A scoring matrix may consist of 4 key-value pairs, 6 key-value pairs, or 7 key-value pairs.  
+The scoring-value is at all times a *<u>positive</u>* integer (number), negative values are **<u>not</u>** supported.
+
+The list of usable keys for the scoring-matrix is as follows:
+
+| key | Explanation | when to use |
+| --- | ---         | ---         |
+| match | The score that is added for every match | always required |
+| mismatch | The penalty score that is applied for every mismatch | always required |
+| gap_o1 | The first gap open penalty that is applied for opening a gap in a sequence | always required |
+| gap_e1 | The first gap extension penalty that is applied for extending a gap in a sequence | always required |
+| gap_o2 | The second gap open penalty that is applied for opening a gap in a sequence | required when giving 6 key-value pairs or more |
+| gap_e2 | The second gap extension penaltythat is applied for extending a gap in a sequence | required when giving 6 key-value pairs or more |
+| mma | The penalty score that is applied for mismatches involving ambiguous bases | required when giving 7 key-value pairs.
+
+!!! Example "Usage examples for providing a custom scoring-matrix through key-value pairs"
+    The following flag is to demonstrate how to provide a custom scoring-matrix with 4 key-value pairs. The order of the key-value pairs does not matter.
+    ```
+    --alignment-scoring match=4 mismatch=2 gap_o1=5 gap_e1=1
+    ```
+
+    The following flag is to demonstrate how to provide a custom scoring-matrix with 6 key-value pairs. The order of these key-value pairs does not matter.
+    ```
+    --alignment-scoring match=4 mismatch=2 gap_o1=5 gap_e1=1 gap_o2=15 gap_e2=0
+    ```
+
+    The following flag is to demonstrate how to provide a custom scoring-matrix with 7 key-value pairs. The order of these key-value pairs does not matter.
+    ```
+    --alignment-scoring match=4 mismatch=2 gap_o1=5 gap_e1=1 gap_o2=15 gap_e2=0 mma=1
+    ```
+
+
 ## Basic usage examples
 
 === "End-to-end amplicons"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,8 +65,8 @@ markdown_extensions:
     - pymdownx.critic
     - pymdownx.details
     - pymdownx.emoji:
-        emoji_index: !!python/name:materialx.emoji.twemoji
-        emoji_generator: !!python/name:materialx.emoji.to_svg
+        emoji_index: !!python/name:material.extensions.emoji.twemoji
+        emoji_generator: !!python/name:material.extensions.emoji.to_svg
     # - pymdownx.highlight:
     #     linenums_style: pymdownx-inline
     - pymdownx.inlinehilite


### PR DESCRIPTION
This is considered a breaking-change as previously set default alignment scoring parameters are removed in favour of default-values determined by the aligner itself.

If you need specific scoring-matrixes for a certain pathogen (i.e. the analysis of RNA viruses often goes better with some adjusted scoring-parameters) then you can set and tune these scorings yourself now