### PR TITLE
Change build system to Hatch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,12 +17,16 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch 'hatchling>=1.27'
 
       - name: Build package
         run: |
-          python -m pip install --upgrade pip
-          python setup.py sdist
+          hatch build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "AmpliGone"
@@ -39,12 +39,8 @@ source-code = "https://github.com/RIVM-bioinformatics/AmpliGone"
 ampligone = "AmpliGone.__main__:main"
 AmpliGone = "AmpliGone.__main__:main"
 
-[tool.setuptools]
-include-package-data = true
-packages = ["AmpliGone"]
-
-[tool.setuptools.dynamic]
-version = {attr = "AmpliGone.__version__"}
+[tool.hatch.version]
+path = "AmpliGone/__init__.py"
 
 [tool.isort]
 atomic = true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,0 @@
-pytest==8.3.2
-pytest-cov==6.0.0
-pylint==3.3.1
-black==24.8.0
-isort==5.13.2
-mypy==1.13.0
-flake8==7.1.1
-bandit==1.7.10


### PR DESCRIPTION
This PR changes the python build system to Hatch (previously setuptools)

This is done due to an issue with setuptools within conda build (this being the version of setuptools that we need doesn't exist within conda-forge due to breaking changes and it seems that it isn't coming any time soon.)